### PR TITLE
Remove VMware: App Closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Here are some resources Coder Quad recommends to prepare for OA's and technical 
 [Hudson River Trading](https://www.hudsonrivertrading.com/careers/job/?gh_jid=82675)| New York | Algo Developer, [SWE](https://www.hudsonrivertrading.com/careers/job/?gh_jid=86641) |
 |[Fidelity](https://jobs.fidelity.com/job-details/13162494/2021-2022-undergraduates-full-stack-engineer-merrimack-nh/)| Boston + others | Full-Stack Engineer |
 |[Stytch](https://jobs.ashbyhq.com/stytch/b4ee9734-3657-4393-8eca-269ae179d7eb) | SF | |
-|[VMWare](https://careers.vmware.com/new-graduates/jobs/R2111971?lang=en-us) | Palo Alto, Atlanta | University Launch SWE |
 |[Cruise](https://boards.greenhouse.io/cruise/jobs/2364685) | SF | |
 |[Nvidia](https://nvidia.wd5.myworkdayjobs.com/UniversityJobs/) | Various | Many SWE New Grad positions |
 |[Airtable](https://boards.greenhouse.io/airtable/jobs/5311220002?) | SF | |


### PR DESCRIPTION
VMWare application for new grad has been closed and the link doesn't work anymore.

I'm not sure if you want it deleted from the list, or just crossed out.